### PR TITLE
Deactivated users status labeling

### DIFF
--- a/views/comment/widgets/comment.php
+++ b/views/comment/widgets/comment.php
@@ -28,6 +28,9 @@ $module = Yii::$app->getModule('comment');
 $occupation = class_exists('\\humhub\\modules\\rocketcore\\widgets\\UserOccupation')
     ? \humhub\modules\rocketcore\widgets\UserOccupation::widget(['model' => $user])
     : '';
+$userDisabled = class_exists('\\humhub\\modules\\musztabel\\widgets\\PattyStatus')
+    ? \humhub\modules\musztabel\widgets\PattyStatus::widget(['model' => $user])
+    : ''; //Helps to check if user is disabled. Returns 'Deactivated' if user's status is not equal to ENABLED. Can be customized in /views/musztabel/widgets/pattyStatus.php
 ?>
 
 <div class="media" id="comment_<?= $comment->id; ?>" data-action-component="comment.Comment" data-content-delete-url="<?= $deleteUrl ?>">
@@ -71,7 +74,13 @@ $occupation = class_exists('\\humhub\\modules\\rocketcore\\widgets\\UserOccupati
         <div class="comment-frame-body">
             <div class="media-body">
                 <h4 class="media-heading">
-                    <?= Html::containerLink($user) ?>
+
+                    <?php if ($userDisabled):?>
+                        <span class="text-danger" style="text-decoration: line-through;"><?= Html::containerLink($user)?></span> &middot <span class="badge" style="background-color: #ff2424;"><?=$userDisabled;?></span>
+                    <?php else:?>
+                        <?= Html::containerLink($user) ?>
+                    <?php endif;?>
+
                     <small>&middot <?= TimeAgo::widget(['timestamp' => $createdAt]) ?>
                         <?php if ($comment->isUpdated()): ?>
                             &middot <?= UpdatedIcon::getByDated($comment->updated_at) ?>

--- a/views/content/widgets/containerProfileHeader.php
+++ b/views/content/widgets/containerProfileHeader.php
@@ -24,6 +24,7 @@
 
     use humhub\modules\content\assets\ContainerHeaderAsset;
     use humhub\modules\file\widgets\Upload;
+    use humhub\modules\user\models\User;
     use yii\helpers\Html;
 
     ContainerHeaderAsset::register($this);
@@ -39,6 +40,9 @@
     $occupation = class_exists('\\humhub\\modules\\rocketcore\\widgets\\UserOccupation')
         ? \humhub\modules\rocketcore\widgets\UserOccupation::widget(['model' => $container])
         : '';
+    $userDisabled = class_exists('\\humhub\\modules\\musztabel\\widgets\\PattyStatus')
+        ? \humhub\modules\musztabel\widgets\PattyStatus::widget(['model' => $container])
+        : ''; //Helps to check if user is disabled. Returns 'Deactivated' if user's status is not equal to ENABLED. Can be customized in /views/musztabel/widgets/pattyStatus.php
 ?>
 
 <?= Html::beginTag('div', $options) ?>
@@ -51,9 +55,13 @@
 
         <!-- show user name and title -->
         <div class="img-profile-data">
-            <h1 class="<?= $classPrefix ?>"><?= Html::encode($title) ?></h1>
+            <?php if($userDisabled) : ?>
+                <h1 class="<?= $classPrefix ?>" style="text-decoration: line-through;"><?= Html::encode($title);?></h1><span class="<?= $classPrefix ?> badge" style="color: #fff; background: #ff2424"><?=$userDisabled?></span>
+            <?php else: ?>
+            <h1 class="<?= $classPrefix ?>"><?= Html::encode($title);?></h1>
             <?= $occupation ?>
             <h2 class="<?= $classPrefix ?>"><?= Html::encode($subTitle) ?></h2>
+            <?php endif;?>
         </div>
 
         <?php if ($canEdit) : ?>

--- a/views/content/widgets/stream/views/wallStreamEntryHeader.php
+++ b/views/content/widgets/stream/views/wallStreamEntryHeader.php
@@ -21,6 +21,9 @@ $container = $model->content->container;
 $occupation = class_exists('\\humhub\\modules\\rocketcore\\widgets\\UserOccupation')
     ? \humhub\modules\rocketcore\widgets\UserOccupation::widget(['model' => $model->content->createdBy])
     : '';
+$userDisabled = class_exists('\\humhub\\modules\\musztabel\\widgets\\PattyStatus')
+    ? \humhub\modules\musztabel\widgets\PattyStatus::widget(['model' => $model->content->createdBy])
+    : ''; //Helps to check if user is disabled. Returns 'Deactivated' if user's status is not equal to ENABLED. Can be customized in /views/musztabel/widgets/pattyStatus.php
 ?>
 
 <div class="stream-entry-icon-list">
@@ -48,7 +51,12 @@ $occupation = class_exists('\\humhub\\modules\\rocketcore\\widgets\\UserOccupati
 <div class="wall-entry-header-info media-body">
 
     <div class="media-heading">
-        <?= $title ?>
+
+        <?php if ($userDisabled):?>
+            <span class="text-danger" style="text-decoration: line-through;"><?= $title;?></span> &middot <span class="badge" style="background-color: #ff2424;"><?=$userDisabled;?></span>
+        <?php else:?>
+            <?= $title;?>
+        <?php endif;?>
 
         <div class="wall-entry-icons">
             <?= VisibilityIcon::getByModel($model) ?>

--- a/views/musztabel/widgets/pattyStatus.php
+++ b/views/musztabel/widgets/pattyStatus.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * This view should be used for customizing user's status badge called with the PattyStatus widget
+ */
+?>
+<span><?=Yii::t('MusztabelModule.base', 'Deactivated');?></span>


### PR DESCRIPTION
Requires Musztabel/PattyStatus widget

Can be globally customized at views/musztabel/widgets/pattyStatus.php